### PR TITLE
(DO NOT MERGE) Reflect missing compiled release assets and disabled issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@
 
 ## Installation
 
-### Download Pre-built Release (Recommended)
-
-1. Go to the [**Releases**](https://github.com/Finesssee/ProxyPilot/releases) page
-2. Download the latest binary for your platform
-3. Run `./proxypilot`
-
 ### Build from Source
 
 ```bash
@@ -357,12 +351,6 @@ Special thanks to these teams for sharing their work and insights.
 ## License
 
 MIT License - see [LICENSE](LICENSE) for details.
-
----
-
-## Support
-
-- **Report Issues**: [GitHub Issues](https://github.com/Finesssee/ProxyPilot/issues)
 
 ---
 


### PR DESCRIPTION
## Description

Issue: The last 2 releases miss the compiled assets. It breaks installing via `mise use -g github:Finesssee/ProxyPilot`

Issue #2: Support is referenced in README, but issues are actually disabled.

Using this way to report. The PR is not intended to merge, unless you aim to stop building precompiled releases and block feedback through issues.
