### PR TITLE
Harden PR and release workflows

### DIFF
--- a/.github/workflows/agents-md-guard.yml
+++ b/.github/workflows/agents-md-guard.yml
@@ -1,7 +1,7 @@
 name: agents-md-guard
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/auto-retarget-main-pr-to-dev.yml
+++ b/.github/workflows/auto-retarget-main-pr-to-dev.yml
@@ -1,7 +1,7 @@
 name: auto-retarget-main-pr-to-dev
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.26.0'
-          cache: true
       - name: Generate Build Metadata
         run: |
           VERSION=$(git describe --tags --always --dirty)


### PR DESCRIPTION
## Summary
- switch PR automation from `pull_request_target` to `pull_request`
- remove Go setup cache from the release workflow
- keep the workflow behavior otherwise unchanged

## Why
Recent supply-chain incidents, including the TanStack compromise, are a reminder that privileged PR/release/publish workflows should minimize shared mutable state. Caches can cross trust boundaries or preserve attacker-influenced artifacts longer than intended, and `pull_request_target` runs with elevated context compared with normal PR workflows.

## Validation
- parsed the touched workflow YAML successfully after the edit
- confirmed the touched workflows no longer reference `pull_request_target` or shared cache directives
